### PR TITLE
Added quotes around run_test commands

### DIFF
--- a/Support/run_single_test.rb
+++ b/Support/run_single_test.rb
@@ -8,7 +8,7 @@ require "#{ENV['TM_BUNDLE_SUPPORT']}/phpunit.rb"
 test_name = TestFinder.find_last_test_before_line(ENV['TM_FILEPATH'], ENV['TM_LINE_NUMBER'])
 file = ENV['TM_FILENAME']
 dir = PHPUnit::Processor.is_remote? ? ENV['TM_DIRECTORY'].gsub(/#{ENV['LOCAL_PATH']}/,ENV["REMOTE_PATH"]) : ENV['TM_DIRECTORY']
-cmd = "cd #{dir}; phpunit --log-xml /tmp/#{file}.xml --filter #{test_name} #{file} > /dev/null; cat /tmp/#{file}.xml; rm /tmp/#{file}.xml"
+cmd = "cd \"#{dir}\"; phpunit --log-xml /tmp/#{file}.xml --filter #{test_name} #{file} > /dev/null; cat /tmp/#{file}.xml; rm /tmp/#{file}.xml"
 if PHPUnit::Processor.is_remote? 
   output = `ssh #{ENV['REMOTE_HOST']} "#{cmd}"`
 else

--- a/Support/run_tests.rb
+++ b/Support/run_tests.rb
@@ -7,7 +7,7 @@ require "#{ENV['TM_BUNDLE_SUPPORT']}/phpunit.rb"
 
 file = ENV['TM_FILENAME']
 dir = PHPUnit::Processor.is_remote? ? ENV['TM_DIRECTORY'].gsub(/#{ENV['LOCAL_PATH']}/,ENV["REMOTE_PATH"]) : ENV['TM_DIRECTORY']
-cmd = "cd #{dir}; phpunit --log-junit /tmp/#{file}.xml #{file} > /dev/null; if [ -f /tmp/#{file}.xml ]; then cat /tmp/#{file}.xml; rm /tmp/#{file}.xml; fi;"
+cmd = "cd \"#{dir}\"; phpunit --log-junit /tmp/#{file}.xml #{file} > /dev/null; if [ -f /tmp/#{file}.xml ]; then cat /tmp/#{file}.xml; rm /tmp/#{file}.xml; fi;"
 if PHPUnit::Processor.is_remote? 
   output = `ssh #{ENV['REMOTE_HOST']} "#{cmd}"`
 else


### PR DESCRIPTION
Hi!

I've enjoyed using the phpunit bundle, but I had a small problem in that my source directory had spaces in the path.  

Simply added quotes around the cmd so that the shell interprets as one string.

Hope that helps!
- Jerry
