### PR TITLE
Assertion counter

### DIFF
--- a/Snippets/assertEquals.tmSnippet
+++ b/Snippets/assertEquals.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>\$this-&gt;assertEquals( ${1:expected}, ${2:actual}${3:, '${4:message}'} );$0</string>
+	<string>\$this-&gt;assertEquals(${1:expected}, ${2:actual}${3:, '${4:message}'});$0</string>
 	<key>name</key>
 	<string>assertEquals</string>
 	<key>scope</key>

--- a/Snippets/assertNotNull.tmSnippet
+++ b/Snippets/assertNotNull.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>\$this-&gt;assertNotNull( {1:\$variable}{2:, '{3:message}'} );$0</string>
+	<string>\$this-&gt;assertNotNull(${1:\$variable}${2:, '${3:message}'});$0</string>
 	<key>name</key>
 	<string>assertNotNull</string>
 	<key>scope</key>

--- a/Support/phpunit.rb
+++ b/Support/phpunit.rb
@@ -25,10 +25,9 @@ module PHPUnit
         results[:parent][:counts][:assertions] = master.attributes.get_attribute('tests').value.to_i
         results[:parent][:status] = (results[:parent][:counts][:fail] +  results[:parent][:counts][:error]) > 0 ? 'fail' : 'pass'
         results[:parent][:total_time] = master.attributes.get_attribute('time').value.to_f
-
-      else
-        testsuites = xml.find("/testsuites/testsuite")
       end
+      
+	  testsuites = xml.find("/testsuites//testsuite")
 
       results[:suites] = []
       testsuites.each do |ts|


### PR DESCRIPTION
There were two instances in the xml processor that seemed to be checking the wrong attributes in the phpunit xml output for the assertion count.

I have updated them in this copy and the count is now correct - however, my ruby skills have not got any better, so although I think I have done it correct, I am not sure if there are any knock on effects.
